### PR TITLE
[codex] Fix qs Dependabot alert

### DIFF
--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  qs: 6.15.2
+
 importers:
 
   .:
@@ -380,8 +383,8 @@ packages:
   pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   range-parser@1.2.1:
@@ -522,7 +525,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -650,7 +653,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -844,7 +847,7 @@ snapshots:
 
   pstree.remy@1.1.8: {}
 
-  qs@6.14.2:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/server/pnpm-workspace.yaml
+++ b/server/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+packages:
+  - '.'
+
+overrides:
+  qs: 6.15.2


### PR DESCRIPTION
Fixes Dependabot alert #158 by overriding the transitive qs dependency used by express/body-parser to 6.15.2. This updates the server pnpm lockfile and adds a pnpm workspace override so the patched qs version remains pinned. Validation: pnpm audit --audit-level moderate returned no known vulnerabilities, pnpm why qs --depth 10 showed only qs@6.15.2, and the advisory PoC no longer throws.